### PR TITLE
fix: 修复 kmarkdown 无法解析服务器表情的问题

### DIFF
--- a/src/utils/fragment/mark2fragment.jsx
+++ b/src/utils/fragment/mark2fragment.jsx
@@ -93,7 +93,7 @@ function parseTag(item, options) {
       break;
     case 'emj':
       fragment = (
-        <img className="emoji custom" src={getCustomEmojiUrl(attrs.join(''))} />
+        <img className="emoji custom" src={getCustomEmojiUrl(attrs.id)} />
       );
       break;
     case 'spl':


### PR DESCRIPTION
原始消息内容：

```markdown
(emj)46(emj)[5107224330983339/G5Kh9bOUiW0e80e8]
```

![image](https://github.com/user-attachments/assets/eee6c8b8-8ae5-4b51-9a53-0744447ab00f)
